### PR TITLE
Update Correction_C#.cs

### DIFF
--- a/Corrections/Correction_C#.cs
+++ b/Corrections/Correction_C#.cs
@@ -8,6 +8,7 @@
 //  Reviewed by:
 //      - Nementon
 //      - (null)
+//		- Adrian Hum (lgm-adrianhum)
 //
 
 using System;

--- a/Corrections/Correction_C#.cs
+++ b/Corrections/Correction_C#.cs
@@ -41,7 +41,12 @@ namespace CSharpCorrection
             string hello = "Hello ";
             hello += name;
             Console.WriteLine(hello);
-
+            // Strings are immutable, so it is preferable to use the string builder class when concatenating.
+            var sb = new StringBuilder();
+            sb.Append("Hello");
+            sb.Append(name);
+            Console.WriteLine(sb.ToString());
+            
             // FIXME: Array
             // create a new string array called "shoppingList", with three elements of your choice. Create an int variable containing the number of
             // elements in "shoppingList" (using a function of the array/using the array)


### PR DESCRIPTION
I just added a small portion to your section on String Concatenation, strings in C# are immutable. So when you 'add' to them a new copy is created with the new contents. This means that as you repeat this process over and over again, you end up with a lot of memory consumed.

For this reason, you should actually use the StringBuilder class when you are assembling a complex string. This is the reason for the pull request.
